### PR TITLE
Tinycad b28

### DIFF
--- a/V2X.py
+++ b/V2X.py
@@ -26,6 +26,13 @@ from mathutils import geometry
 
 def add_vertex_to_intersection():
     objs = bpy.context.selected_objects
+    fobj = bpy.context.active_object
+    #making sure the active object is the last object in the "objs"-list
+    #Important as it makes sure the new vertex is added
+    #in the mesh of the object of which the edge was selected first
+    objs.remove(fobj)
+    objs.append(fobj)
+    
     #working with one object
     if len(objs)==1:
         me = objs[0].data

--- a/__init__.py
+++ b/__init__.py
@@ -25,7 +25,7 @@ bl_info = {
     "version": (1, 3, 2),
     "blender": (2, 80, 0),
     "category": "Mesh",
-    "location": "View3D > EditMode > (w) Specials",
+    "location": "View3D > EditMode Context Menu",
     "wiki_url": "http://zeffii.github.io/mesh_tiny_cad/",
     "tracker_url": "https://github.com/zeffii/mesh_tiny_cad/issues"
 }
@@ -75,11 +75,11 @@ def register():
         bpy.utils.register_class(cls)
     bpy.types.Scene.tinycad_props = bpy.props.PointerProperty(
         name="TinyCAD props", type=TinyCADProperties)
-    bpy.types.VIEW3D_MT_edit_mesh_specials.prepend(menu_func)
+    bpy.types.VIEW3D_MT_edit_mesh_context_menu.prepend(menu_func)
 
 
 def unregister():
-    bpy.types.VIEW3D_MT_edit_mesh_specials.remove(menu_func)
+    bpy.types.VIEW3D_MT_edit_mesh_context_menu.remove(menu_func)
     for cls in reversed(classes):
         bpy.utils.unregister_class(cls)
     del bpy.types.Scene.tinycad_props


### PR DESCRIPTION
Slight adjustment to the "__init__.py" to work with 2.8, "bpy.types.VIEW3D_MT_edit_mesh_specials" had been dropped.

Also included my version of the V2X (2 objects) solution which i worked over.
It's now generating and adding the new vertex at the intersection in the mesh of the object of which the edge was selected first. That way just by selecting the 2 edges for the function in different order the user can decide which object will get the new vertex.